### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#Query like syntax to filter repositories represented in JSON. 
+# Query like syntax to filter repositories represented in JSON. 
 
 Feel free to check the example and read more about it [here](http://www.dzautner.com/blog/2013/12/31/metaprogramming-javascript-using-proxies/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
